### PR TITLE
Add json to defaultSettings/enabledLanguageIds

### DIFF
--- a/server/src/DefaultSettings.ts
+++ b/server/src/DefaultSettings.ts
@@ -55,7 +55,7 @@ const defaultDictionaryDefs: DictionaryDefinition[] = [
 const defaultSettings: CSpellUserSettings = {
     language: 'en',
     enabledLanguageIds: [
-        'csharp', 'go', 'javascript', 'javascriptreact', 'markdown',
+        'csharp', 'go', 'javascript', 'javascriptreact', 'json', 'markdown',
         'php', 'plaintext', 'python', 'text', 'typescript', 'typescriptreact'
     ],
     maxNumberOfProblems: 100,


### PR DESCRIPTION
Thanks for this excellent extension!

Is there a reason why json shouldn't work with a default installation?
