### PR TITLE
Pinning to Typescript 2.1.5

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -42,7 +42,7 @@
     "mocha": "^3.2",
     "rimraf": "^2.5.4",
     "ts-node": "^2.0.0",
-    "typescript": "^2.1.5"
+    "typescript": "2.1.5"
   },
   "scripts": {
     "clean": "rimraf ../client/server && rimraf ./tools/out",


### PR DESCRIPTION
Typescript 2.2.0 is in RC and npm is already downloading it based on the previous dependency version rules.

VSCode is currently using 2.1.5, so it seems to make sense to follow that version. 

Additionally the 2.2 compiler has a breaking change with lodash that prevents building spellchecker if tsc 2.2 is used.  cf.  https://github.com/DefinitelyTyped/DefinitelyTyped/pull/14502

Once the lodash fix is merged and a new @types/lodash published, this commit can be reverted.