### PR TITLE
Removed redundant camelCase example in README

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -58,7 +58,6 @@ To *Enable* or *Disable* spell checking for a file type:
 The concept is simple, split camelCase words before checking them against a list of known English words.
 * camelCase -> camel case
 * HTMLInput -> html input
-* srcCode -> src code
 * snake_case_words -> snake case words
 * camel2snake -> camel snake -- (the 2 is ignored)
 


### PR DESCRIPTION
In readme there is a number of examples how words are processed.

One of them "srcCode" is an example of exact same rule as "camelCase" thus I think it might be simply removed to shorten README.