### PR TITLE
add available options to cSpell.language rather than having to type them

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -93,7 +93,11 @@
                 "cSpell.language": {
                     "type": "string",
                     "default": "en",
-                    "description": "The Language local to use when spell checking. \"en\" and \"en-GB\" are currently supported. "
+                    "description": "The Language local to use when spell checking. \"en\" and \"en-GB\" are currently supported.",
+                    "enum": [
+                        "en",
+                        "en-GB"
+                    ]
                 },
                 "cSpell.maxNumberOfProblems": {
                     "type": "number",


### PR DESCRIPTION
Just to make it easier to change the language (i'm lazy)