### PR TITLE
Adding support for Visual Studio Live Share

### DIFF
--- a/client/src/client/client.ts
+++ b/client/src/client/client.ts
@@ -49,7 +49,8 @@ export class CSpellClient {
             .filter(uniqueFilter());
         const documentSelector =
             uniqueLangIds.map(language => ({ language, scheme }))
-            .concat(uniqueLangIds.map(language => ({ language, scheme: 'untitled' })));
+            .concat(uniqueLangIds.map(language => ({ language, scheme: 'untitled' })))
+            .concat(uniqueLangIds.map(language => ({ language, scheme: 'vsls' })));
         // Options to control the language client
         const clientOptions: LanguageClientOptions = {
             documentSelector,

--- a/client/src/util/uriHelper.ts
+++ b/client/src/util/uriHelper.ts
@@ -1,7 +1,7 @@
 
 import * as vscode from 'vscode';
 
-export const supportedSchemes = ['file', 'untitled'];
+export const supportedSchemes = ['file', 'untitled', 'vsls'];
 export const setOfSupportedSchemes = new Set(supportedSchemes);
 
 export function isSupportedUri(uri?: vscode.Uri): boolean {


### PR DESCRIPTION
This PR adds support for [Visual Studio Live Share](https://aka.ms/vsls), and is the accompanying change to [this CSpell PR](https://github.com/Jason3S/cspell/pull/28). With this change in place, all developers that join a Live Share collaboration session, and have this extension installed, will be able to continue benefiting from the spell checking behavior they would expect (which could be really important for pairing/mentoring/etc. scenarios):

<img width="1016" alt="screen shot 2018-02-24 at 10 14 43 pm" src="https://user-images.githubusercontent.com/116461/36638658-29da0944-19b0-11e8-82e9-b0e3dd9eb0ad.png">

After [this CSpell PR](https://github.com/Jason3S/cspell/pull/28) was merged, it would obviously need to be published to NPM, and depending on the new version, [this dependency](https://github.com/Jason-Rev/vscode-spell-checker/blob/master/server/package.json#L16) would need to be updated. However, this change could still be made separately, since it would have the affect of making the status bar item begin showing up on the "guest" side, however, it would still show spell checking as disabled unless the LSP server was using the latest `cspell` with my change.

// CC @Jason-Rev @Jason3S 