### PR TITLE
Adding support for AsciiDoc out of the box

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -59,6 +59,7 @@ Open up VS Code and hit `F1` and type `ext` select install and type `code-spell-
 * PHP
 * Python
 * YAML
+* AsciiDoc
 
 ### Enable / Disable File Types
 

--- a/client/package.json
+++ b/client/package.json
@@ -138,6 +138,7 @@
                         "type": "string"
                     },
                     "default": [
+                        "asciidoc",
                         "c",
                         "cpp",
                         "csharp",

--- a/client/src/settings/languageIds.ts
+++ b/client/src/settings/languageIds.ts
@@ -1,4 +1,5 @@
 export const languageIds: string[] = [
+    'asciidoc',
     'bat',
     'c',
     'clojure',


### PR DESCRIPTION
[AsciiDoc](https://en.wikipedia.org/wiki/AsciiDoc) is a documentation format in the same vein as markdown and restructuredtext (both currently supported by default). Documentation, like [Pro Git 2](https://github.com/progit/progit2), the Git Book, are written in it. This pull request is to add it as supported out of the box.