### PR TITLE
[Live Share] Restricting language services to local files

### DIFF
--- a/client/src/client/client.ts
+++ b/client/src/client/client.ts
@@ -49,8 +49,7 @@ export class CSpellClient {
             .filter(uniqueFilter());
         const documentSelector =
             uniqueLangIds.map(language => ({ language, scheme }))
-            .concat(uniqueLangIds.map(language => ({ language, scheme: 'untitled' })))
-            .concat(uniqueLangIds.map(language => ({ language, scheme: 'vsls' })));
+            .concat(uniqueLangIds.map(language => ({ language, scheme: 'untitled' })));
         // Options to control the language client
         const clientOptions: LanguageClientOptions = {
             documentSelector,

--- a/client/src/util/uriHelper.ts
+++ b/client/src/util/uriHelper.ts
@@ -1,7 +1,7 @@
 
 import * as vscode from 'vscode';
 
-export const supportedSchemes = ['file', 'untitled', 'vsls'];
+export const supportedSchemes = ['file', 'untitled'];
 export const setOfSupportedSchemes = new Set(supportedSchemes);
 
 export function isSupportedUri(uri?: vscode.Uri): boolean {


### PR DESCRIPTION
This is the corresponding PR for https://github.com/Jason3S/cspell/pull/31, and effectively reverts #191. As described in the CSPell PR, the reason for reverting this change is because we've enhanced Live Share to allow arbitrary language services to be remoted from the host to their guests, as opposed to relying on guests to also run them locally (e.g. spell checking). In this case, by ensuring that only the host runs spell checking (who would have access to `file` documents), it prevents a guest (who has access to `vsls` documents) from seeing duplicated diagnostics if they also have this extension installed.