### PR TITLE
[Discussion] Restricting code actions to allowed doc URIs

### DIFF
--- a/server/src/codeActions.ts
+++ b/server/src/codeActions.ts
@@ -11,6 +11,7 @@ import { CSpellUserSettings } from 'cspell';
 import { SpellingDictionary } from 'cspell';
 import * as cspell from 'cspell';
 import { CompoundWordsMethod } from 'cspell-trie/dist/lib/walker';
+import { isUriAllowed } from './documentSettings';
 
 const defaultNumSuggestions = 10;
 
@@ -62,11 +63,15 @@ export function onCodeActionHandler(
     return async (params: CodeActionParams) => {
         const commands: Command[] = [];
         const { context, textDocument: { uri } } = params;
+        
+        if (!isUriAllowed(uri)) {
+            return [];
+        }
         const { diagnostics } = context;
         const textDocument = documents.get(uri);
         const [ docSetting, dictionary ] = await getSettings(textDocument);
         const { numSuggestions = defaultNumSuggestions } = docSetting;
-
+        
         function replaceText(range: LangServer.Range, text?: string) {
             return LangServer.TextEdit.replace(range, text || '');
         }

--- a/server/src/documentSettings.ts
+++ b/server/src/documentSettings.ts
@@ -219,7 +219,7 @@ function readSettingsFiles(paths: string[]) {
     return CSpell.readSettingsFiles(existingPaths);
 }
 
-export function isUriAllowed(uri: string, schemas: string[] | undefined) {
+export function isUriAllowed(uri: string, schemas?: string[]) {
     schemas = schemas || defaultAllowedSchemas;
     return doesUriMatchAnySchema(uri, schemas);
 }


### PR DESCRIPTION
I noticed that even though the `LanguageClient`'s `DocumentSelector` explicitly specifies the the `file` and `untitled` schemes, the LSP server's code action handler still runs for all documents. Is this expected? I took a quick look at the codebase to see whether code actions "break" outside of the document selector somehow, but I didn't see anything obvious.

As a workaround, this PR simply restricts code actions to the set of supported URI types (which diagnostics already do successfully).

// CC @Jason3S 