### PR TITLE
Add rst to the list of enabled file types

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -60,6 +60,7 @@ Open up VS Code and hit `F1` and type `ext` select install and type `code-spell-
 * Python
 * YAML
 * AsciiDoc
+* reStructuredText
 
 ### Enable / Disable File Types
 


### PR DESCRIPTION
I started using this spellchecker as I was writing documentation in
reStructuredText and I noticed rst wasn't listed as an enabled file type.
I dug around to see how to enable the spellchecker for rst documents
however it seemed as though the spellchecker is actually enabled for
reStructuredText out of the box.

I thought it might be helpful to include it in the list of enabled file
types in the readme.